### PR TITLE
add type hinting with PHP 8

### DIFF
--- a/pam.c
+++ b/pam.c
@@ -18,8 +18,6 @@
   +----------------------------------------------------------------------+
 */
 
-/* $Id$ */
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -30,6 +28,12 @@
 #include "php_pam.h"
 #include <security/pam_appl.h>
 #include <security/_pam_macros.h>
+
+#if PHP_VERSION_ID < 80000
+#include "pam_legacy_arginfo.h"
+#else
+#include "pam_arginfo.h"
+#endif
 
 ZEND_DECLARE_MODULE_GLOBALS(pam)
 
@@ -314,41 +318,12 @@ PHP_MINFO_FUNCTION(pam)
 }
 /* }}} */
 
-/* {{{ arginfo */
-ZEND_BEGIN_ARG_INFO_EX(arginfo_pam_auth, 0, 0, 2)
-    ZEND_ARG_INFO(0, username)
-    ZEND_ARG_INFO(0, password)
-    ZEND_ARG_INFO(1, status)
-    ZEND_ARG_INFO(0, checkacctmgmt)
-    ZEND_ARG_INFO(0, servicename)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_pam_chpass, 0, 0, 3)
-    ZEND_ARG_INFO(0, username)
-    ZEND_ARG_INFO(0, oldpassword)
-    ZEND_ARG_INFO(0, newpassword)
-    ZEND_ARG_INFO(1, status)
-    ZEND_ARG_INFO(0, servicename)
-ZEND_END_ARG_INFO()
-/* }}} */
-
-/* {{{ pam_functions[]
- *
- * Every user visible function must have an entry in pam_functions[].
- */
-const zend_function_entry pam_functions[] = {
-	PHP_FE(pam_auth,	arginfo_pam_auth)
-	PHP_FE(pam_chpass,	arginfo_pam_chpass)
-	PHP_FE_END	/* Must be the last line in pam_functions[] */
-};
-/* }}} */
-
 /* {{{ pam_module_entry
  */
 zend_module_entry pam_module_entry = {
 	STANDARD_MODULE_HEADER,
 	"pam",
-	pam_functions,
+	ext_functions,
 	PHP_MINIT(pam),
 	PHP_MSHUTDOWN(pam),
 	NULL,	/* Replace with NULL if there's nothing to do at request start */

--- a/pam.stub.php
+++ b/pam.stub.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @generate-function-entries
+ * @generate-legacy-arginfo
+ */
+
+/** @param string $status */
+function pam_auth(string $username, string $password, &$status = null, bool $checkacctmgmt = true, string $servicename = null): bool {}
+
+/** @param string $status */
+function pam_chpass(string $username, string $oldpassword, string $newpassword, &$status = null, string $servicename = null): bool {}
+

--- a/pam_arginfo.h
+++ b/pam_arginfo.h
@@ -1,0 +1,29 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 5d7edd77ec802eac610edf6086a09ea41aa67afb */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pam_auth, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, username, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, password, IS_STRING, 0)
+	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, status, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, checkacctmgmt, _IS_BOOL, 0, "true")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, servicename, IS_STRING, 0, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pam_chpass, 0, 3, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, username, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, oldpassword, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, newpassword, IS_STRING, 0)
+	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, status, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, servicename, IS_STRING, 0, "null")
+ZEND_END_ARG_INFO()
+
+
+ZEND_FUNCTION(pam_auth);
+ZEND_FUNCTION(pam_chpass);
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_FE(pam_auth, arginfo_pam_auth)
+	ZEND_FE(pam_chpass, arginfo_pam_chpass)
+	ZEND_FE_END
+};

--- a/pam_legacy_arginfo.h
+++ b/pam_legacy_arginfo.h
@@ -1,0 +1,29 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 5d7edd77ec802eac610edf6086a09ea41aa67afb */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_pam_auth, 0, 0, 2)
+	ZEND_ARG_INFO(0, username)
+	ZEND_ARG_INFO(0, password)
+	ZEND_ARG_INFO(1, status)
+	ZEND_ARG_INFO(0, checkacctmgmt)
+	ZEND_ARG_INFO(0, servicename)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_pam_chpass, 0, 0, 3)
+	ZEND_ARG_INFO(0, username)
+	ZEND_ARG_INFO(0, oldpassword)
+	ZEND_ARG_INFO(0, newpassword)
+	ZEND_ARG_INFO(1, status)
+	ZEND_ARG_INFO(0, servicename)
+ZEND_END_ARG_INFO()
+
+
+ZEND_FUNCTION(pam_auth);
+ZEND_FUNCTION(pam_chpass);
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_FE(pam_auth, arginfo_pam_auth)
+	ZEND_FE(pam_chpass, arginfo_pam_chpass)
+	ZEND_FE_END
+};


### PR DESCRIPTION
Take benefit of PHP 8 feature: generate arginfo from stub.php

This also add type hints

Previous version

```
    Function [ <internal:pam> function pam_auth ] {

      - Parameters [5] {
        Parameter #0 [ <required> $username ]
        Parameter #1 [ <required> $password ]
        Parameter #2 [ <optional> &$status ]
        Parameter #3 [ <optional> $checkacctmgmt ]
        Parameter #4 [ <optional> $servicename ]
      }
    }
    Function [ <internal:pam> function pam_chpass ] {

      - Parameters [5] {
        Parameter #0 [ <required> $username ]
        Parameter #1 [ <required> $oldpassword ]
        Parameter #2 [ <required> $newpassword ]
        Parameter #3 [ <optional> &$status ]
        Parameter #4 [ <optional> $servicename ]
      }
    }
```

With this proposal

```
    Function [ <internal:pam> function pam_auth ] {

      - Parameters [5] {
        Parameter #0 [ <required> string $username ]
        Parameter #1 [ <required> string $password ]
        Parameter #2 [ <optional> &$status = null ]
        Parameter #3 [ <optional> bool $checkacctmgmt = true ]
        Parameter #4 [ <optional> string $servicename = null ]
      }
      - Return [ bool ]
    }
    Function [ <internal:pam> function pam_chpass ] {

      - Parameters [5] {
        Parameter #0 [ <required> string $username ]
        Parameter #1 [ <required> string $oldpassword ]
        Parameter #2 [ <required> string $newpassword ]
        Parameter #3 [ <optional> &$status = null ]
        Parameter #4 [ <optional> string $servicename = null ]
      }
      - Return [ bool ]
    }

```

Notice: All 3 new files need to be added in package.xml

* Only PHP 8 will generate arginfo.h
* PHP 8 will use pam_arginfo.h
* PHP 7 will uses pam_legacy_arginfo.h
* 