### PR TITLE
Update TSRMLS_CACHE in RINIT_FUNCTION and MINIT_FUNCTION

### DIFF
--- a/pam.c
+++ b/pam.c
@@ -289,6 +289,9 @@ static void php_pam_init_globals(zend_pam_globals *pam_globals)
  */
 PHP_MINIT_FUNCTION(pam)
 {
+#if defined(ZTS) && defined(COMPILE_DL_PAM)
+	ZEND_TSRMLS_CACHE_UPDATE();
+#endif
 	ZEND_INIT_MODULE_GLOBALS(pam, php_pam_init_globals, NULL);
 	REGISTER_INI_ENTRIES();
 	return SUCCESS;
@@ -300,6 +303,17 @@ PHP_MINIT_FUNCTION(pam)
 PHP_MSHUTDOWN_FUNCTION(pam)
 {
 	UNREGISTER_INI_ENTRIES();
+	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ PHP_RINIT_FUNCTION
+ */
+PHP_RINIT_FUNCTION(pam)
+{
+#if defined(ZTS) && defined(COMPILE_DL_PAM)
+	ZEND_TSRMLS_CACHE_UPDATE();
+#endif
 	return SUCCESS;
 }
 /* }}} */
@@ -325,7 +339,7 @@ zend_module_entry pam_module_entry = {
 	ext_functions,
 	PHP_MINIT(pam),
 	PHP_MSHUTDOWN(pam),
-	NULL,	/* Replace with NULL if there's nothing to do at request start */
+	PHP_RINIT(pam),
 	NULL,	/* Replace with NULL if there's nothing to do at request end */
 	PHP_MINFO(pam),
 	PHP_PAM_VERSION,


### PR DESCRIPTION
When extension is compiled in ZTS mode as a dynamic library both the extension and the php executable have their own copy of global thread-local variable `_tsrm_ls_cache` (a.k.a `TSRMLS_CACHE`).
When extension is compiled with define `ZEND_ENABLE_STATIC_TSRMLS_CACHE` (which is non-configurable and enabled by default in the build system) the extension uses that variable directly instead of going through `tsrm_get_ls_cache()` function, so it is important that both copies stay synchronized.
If they are not kept in sync then extension may use it own copy which is only initialized to `NULL` and crash on accessing its module global.

This synchronization should be done on each request as different requests may be handled in different (new) threads (e.g. in Apache's mod_php when a threaded MPM is used).
We also do this in `MINIT_FUNCTION` just in case.

Fixes: #11 